### PR TITLE
feat(entity.cs): add audit fields to entities for tracking changes

### DIFF
--- a/ABC.PostGreSQL/Migrations/20250506153724_AddAuditFields.Designer.cs
+++ b/ABC.PostGreSQL/Migrations/20250506153724_AddAuditFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ABC.PostGreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ABC.PostGreSQL.Migrations
 {
     [DbContext(typeof(ABCContext))]
-    partial class ABCContextModelSnapshot : ModelSnapshot
+    [Migration("20250506153724_AddAuditFields")]
+    partial class AddAuditFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ABC.PostGreSQL/Migrations/20250506153724_AddAuditFields.cs
+++ b/ABC.PostGreSQL/Migrations/20250506153724_AddAuditFields.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ABC.PostGreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Consequences",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Consequences",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Consequences",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Children",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Children",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Children",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Behaviors",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Behaviors",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Behaviors",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Antecedents",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Antecedents",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Antecedents",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "Consequences");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Consequences");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Consequences");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "Children");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Children");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Children");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "Behaviors");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Behaviors");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Behaviors");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "Antecedents");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Antecedents");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Antecedents");
+        }
+    }
+}

--- a/ABC.SharedKernel/Entity.cs
+++ b/ABC.SharedKernel/Entity.cs
@@ -3,6 +3,12 @@
 public abstract class Entity(Guid id) : IEquatable<Entity>
 {
     public Guid Id { get; init; } = id;
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; private set; } = DateTime.UtcNow;
+    public string CreatedBy { get; init; } = Thread.CurrentPrincipal?.Identity?.Name ?? "System";
+
+    public void SetUpdatedAt() =>
+        UpdatedAt = DateTime.UtcNow;
 
     public bool Equals(Entity? other) =>
         other?.Id.Equals(Id) ?? false;


### PR DESCRIPTION
This commit introduces `CreatedAt`, `CreatedBy`, and `UpdatedAt` fields to the `Antecedents`, `Behaviors`, `Children`, and `Consequences` tables in the database schema. Migration files have been created to define these schema changes, and the `ABCContextModelSnapshot.cs` file has been updated to reflect the new model structure. Additionally, the base `Entity.cs` class has been modified to include these audit properties, ensuring all derived entities automatically have these fields populated.

fix #5 