### PR TITLE
refactor(abc.postgresql): refactor PostgreSQL configuration and proje…

### DIFF
--- a/ABC.AppHost/Program.cs
+++ b/ABC.AppHost/Program.cs
@@ -8,6 +8,8 @@ var databaseNameParameter = builder.AddParameter(dbNameKey);
 
 
 IResourceBuilder<ProjectResource> managementApi;
+// In non-publish mode (e.g., local development), use a direct PostgreSQL configuration.
+// This setup allows developers to run the application locally with a lightweight database.
 if (!builder.ExecutionContext.IsPublishMode)
 {
     var db = builder.AddPostgres("postgres")

--- a/ABC.Management.Api.Tests/ABC.Management.Api.Tests.csproj
+++ b/ABC.Management.Api.Tests/ABC.Management.Api.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ABC.Management.Api\ABC.Management.Api.csproj" />
+    <ProjectReference Include="..\ABC.Management.Domain\ABC.Management.Domain.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ABC.Management.Api.Tests/StartupFixture.cs
+++ b/ABC.Management.Api.Tests/StartupFixture.cs
@@ -1,13 +1,12 @@
 using ABC.Management.Domain.Entities;
 using ABC.Management.Domain.Validators;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 using FakeItEasy;
 using FluentValidation;
 using HotChocolate.Resolvers;
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
-using Reqnroll.Assist;
 using Xunit;
 
 namespace ABC.Management.Api.Tests;

--- a/ABC.Management.Api.Tests/StepDefinitions/CreateAntecedentResponseStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/CreateAntecedentResponseStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 using FakeItEasy;
 using FluentValidation;

--- a/ABC.Management.Api.Tests/StepDefinitions/CreateBehaviorStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/CreateBehaviorStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 using FakeItEasy;
 using FluentValidation;

--- a/ABC.Management.Api.Tests/StepDefinitions/CreateChildConditionStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/CreateChildConditionStepDefinitions.cs
@@ -2,17 +2,14 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
-using ABC.PostGreSQL.ValidationServices;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
-using Bogus.DataSets;
 using FakeItEasy;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Reqnroll;
 using Shouldly;
-using System;
 
 namespace ABC.Management.Api.Tests.StepDefinitions;
 

--- a/ABC.Management.Api.Tests/StepDefinitions/CreateChildStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/CreateChildStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 using Bogus;
 using Bogus.DataSets;

--- a/ABC.Management.Api.Tests/StepDefinitions/CreateConsequenceStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/CreateConsequenceStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 using FakeItEasy;
 using FluentValidation;

--- a/ABC.Management.Api.Tests/StepDefinitions/QueryStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/QueryStepDefinitions.cs
@@ -1,4 +1,4 @@
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Reqnroll;

--- a/ABC.Management.Api.Tests/StepDefinitions/RemoveAntecedentStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/RemoveAntecedentStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/ABC.Management.Api.Tests/StepDefinitions/RemoveBehaviorStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/RemoveBehaviorStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/ABC.Management.Api.Tests/StepDefinitions/RemoveChildConditionStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/RemoveChildConditionStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/ABC.Management.Api.Tests/StepDefinitions/RemoveChildStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/RemoveChildStepDefinitions.cs
@@ -2,7 +2,7 @@ using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/ABC.Management.Api.Tests/StepDefinitions/RemoveConsequenceStepDefinitions.cs
+++ b/ABC.Management.Api.Tests/StepDefinitions/RemoveConsequenceStepDefinitions.cs
@@ -1,9 +1,8 @@
 using ABC.Management.Api.Commands;
 using ABC.Management.Api.Decorators;
 using ABC.Management.Api.Handlers;
-using ABC.Management.Api.Types;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/ABC.Management.Api/Handlers/CreateAntecedentResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/CreateAntecedentResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/CreateBehaviorResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/CreateBehaviorResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/CreateChildConditionResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/CreateChildConditionResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/CreateChildResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/CreateChildResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 using System.Collections;
 

--- a/ABC.Management.Api/Handlers/CreateConsequenceResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/CreateConsequenceResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/RemoveAntecedentResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/RemoveAntecedentResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/RemoveBehaviorResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/RemoveBehaviorResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/RemoveChildConditionResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/RemoveChildConditionResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/RemoveChildResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/RemoveChildResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Handlers/RemoveConsequenceResponseHandler.cs
+++ b/ABC.Management.Api/Handlers/RemoveConsequenceResponseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using Mediator;
 
 namespace ABC.Management.Api.Handlers;

--- a/ABC.Management.Api/Types/Antecedents.cs
+++ b/ABC.Management.Api/Types/Antecedents.cs
@@ -1,7 +1,7 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Api.Extensions;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using HotChocolate.Resolvers;
 using Mediator;
 

--- a/ABC.Management.Api/Types/Behaviors.cs
+++ b/ABC.Management.Api/Types/Behaviors.cs
@@ -1,7 +1,7 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Api.Extensions;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using HotChocolate.Resolvers;
 using Mediator;
 

--- a/ABC.Management.Api/Types/ChildConditions.cs
+++ b/ABC.Management.Api/Types/ChildConditions.cs
@@ -1,7 +1,7 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Api.Extensions;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using HotChocolate.Resolvers;
 using Mediator;
 

--- a/ABC.Management.Api/Types/Children.cs
+++ b/ABC.Management.Api/Types/Children.cs
@@ -1,7 +1,7 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Api.Extensions;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using HotChocolate.Resolvers;
 using Mediator;
 

--- a/ABC.Management.Api/Types/Consequences.cs
+++ b/ABC.Management.Api/Types/Consequences.cs
@@ -1,7 +1,7 @@
 ﻿using ABC.Management.Api.Commands;
 using ABC.Management.Api.Extensions;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
+using ABC.SharedEntityFramework;
 using HotChocolate.Resolvers;
 using Mediator;
 

--- a/ABC.PostGreSQL/ABC.PostGreSQL.csproj
+++ b/ABC.PostGreSQL/ABC.PostGreSQL.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ABC.Management.Domain\ABC.Management.Domain.csproj" />
+    <ProjectReference Include="..\ABC.SharedEntityFramework\ABC.SharedEntityFramework.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ABC.PostGreSQL/Extensions/DependencyInjection.cs
+++ b/ABC.PostGreSQL/Extensions/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using ABC.Management.Domain.Entities;
 using ABC.PostGreSQL.ValidationServices;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/ABC.PostGreSQL/UnitOfWork.cs
+++ b/ABC.PostGreSQL/UnitOfWork.cs
@@ -1,4 +1,5 @@
-﻿using ABC.Management.Domain.Entities;
+﻿using ABC.SharedEntityFramework;
+using ABC.Management.Domain.Entities;
 using ABC.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 

--- a/ABC.PostGreSQL/ValidationServices/AntecedentService.cs
+++ b/ABC.PostGreSQL/ValidationServices/AntecedentService.cs
@@ -1,5 +1,6 @@
 ﻿using ABC.Management.Domain.Entities;
-using ABC.SharedKernel;    
+using ABC.SharedEntityFramework;
+using ABC.SharedKernel;
 
 namespace ABC.PostGreSQL.ValidationServices;
 

--- a/ABC.PostGreSQL/ValidationServices/BehaviorService.cs
+++ b/ABC.PostGreSQL/ValidationServices/BehaviorService.cs
@@ -1,4 +1,5 @@
 ﻿using ABC.Management.Domain.Entities;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 
 namespace ABC.PostGreSQL.ValidationServices;

--- a/ABC.PostGreSQL/ValidationServices/ChildConditionService.cs
+++ b/ABC.PostGreSQL/ValidationServices/ChildConditionService.cs
@@ -1,4 +1,5 @@
 ﻿using ABC.Management.Domain.Entities;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 
 namespace ABC.PostGreSQL.ValidationServices;

--- a/ABC.PostGreSQL/ValidationServices/ConsequenceService.cs
+++ b/ABC.PostGreSQL/ValidationServices/ConsequenceService.cs
@@ -1,4 +1,5 @@
 ﻿using ABC.Management.Domain.Entities;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 
 namespace ABC.PostGreSQL.ValidationServices;

--- a/ABC.PostgreSQL.Tests/StartupFixture.cs
+++ b/ABC.PostgreSQL.Tests/StartupFixture.cs
@@ -1,6 +1,7 @@
 ﻿using ABC.Management.Domain.Entities;
 using ABC.PostGreSQL;
 using ABC.PostGreSQL.ValidationServices;
+using ABC.SharedEntityFramework;
 using ABC.SharedKernel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/ABC.PostgreSQL.Tests/StepDefinitions/AntecedentRepositoryStepDefinitions.cs
+++ b/ABC.PostgreSQL.Tests/StepDefinitions/AntecedentRepositoryStepDefinitions.cs
@@ -1,5 +1,4 @@
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
 using Bogus.DataSets;
 using Shouldly;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +7,7 @@ using System;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
+using ABC.SharedEntityFramework;
 
 namespace ABC.PostgreSQL.Tests.StepDefinitions;
 

--- a/ABC.PostgreSQL.Tests/StepDefinitions/AntecedentServiceStepDefinitions.cs
+++ b/ABC.PostgreSQL.Tests/StepDefinitions/AntecedentServiceStepDefinitions.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
 using ABC.PostGreSQL.ValidationServices;
 using Shouldly;
 using Microsoft.Extensions.DependencyInjection;
 using Reqnroll;
+using ABC.SharedEntityFramework;
 
 namespace ABC.PostgreSQL.Tests.StepDefinitions;
 

--- a/ABC.PostgreSQL.Tests/StepDefinitions/BehaviorServiceStepDefinitions.cs
+++ b/ABC.PostgreSQL.Tests/StepDefinitions/BehaviorServiceStepDefinitions.cs
@@ -1,5 +1,4 @@
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
 using ABC.SharedKernel;
 using Bogus.DataSets;
 using Shouldly;
@@ -9,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ABC.SharedEntityFramework;
 
 namespace ABC.PostgreSQL.Tests.StepDefinitions;
 

--- a/ABC.PostgreSQL.Tests/StepDefinitions/ConsequenceServiceStepDefinitions.cs
+++ b/ABC.PostgreSQL.Tests/StepDefinitions/ConsequenceServiceStepDefinitions.cs
@@ -1,5 +1,4 @@
 using ABC.Management.Domain.Entities;
-using ABC.PostGreSQL;
 using ABC.SharedKernel;
 using Bogus.DataSets;
 using Shouldly;
@@ -8,6 +7,7 @@ using Reqnroll;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using ABC.SharedEntityFramework;
 
 namespace ABC.PostgreSQL.Tests.StepDefinitions;
 

--- a/ABC.SharedEntityFramework/ABC.SharedEntityFramework.csproj
+++ b/ABC.SharedEntityFramework/ABC.SharedEntityFramework.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ABC.Management.Domain\ABC.Management.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ABC.SharedEntityFramework/IUnitOfWork.cs
+++ b/ABC.SharedEntityFramework/IUnitOfWork.cs
@@ -1,7 +1,7 @@
 ﻿using ABC.Management.Domain.Entities;
 using ABC.SharedKernel;
 
-namespace ABC.PostGreSQL;
+namespace ABC.SharedEntityFramework;
 
 public interface IUnitOfWork : IDisposable
 {

--- a/ABC.SharedEntityFramework/RepositoryBase.cs
+++ b/ABC.SharedEntityFramework/RepositoryBase.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Data;
 using System.Linq.Expressions;
 
-namespace ABC.PostGreSQL;
+namespace ABC.SharedEntityFramework;
 public class RepositoryBase<TContext,TEntity> : IRepository<TEntity> 
     where TEntity : Entity
     where TContext : DbContext

--- a/ABC.slnx
+++ b/ABC.slnx
@@ -22,5 +22,6 @@
   <Project Path="ABC.Management.Api/ABC.Management.Api.csproj" />
   <Project Path="ABC.Management.Domain/ABC.Management.Domain.csproj" />
   <Project Path="ABC.PostGreSQL/ABC.PostGreSQL.csproj" />
+  <Project Path="ABC.SharedEntityFramework/ABC.SharedEntityFramework.csproj" />
   <Project Path="ABC.SharedKernel/ABC.SharedKernel.csproj" Id="d31d86b9-a928-6032-b253-33b99a8828c2" />
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Mediator.SourceGenerator" Version="3.0.0-preview.55" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/aspire-rollback.txt
+++ b/aspire-rollback.txt
@@ -1,0 +1,3 @@
+{
+  "microsoft.net.sdk.aspire": "8.0.0-preview.6.24214.1/8.0.100"
+}


### PR DESCRIPTION
Updated `Program.cs` to replace Azure PostgreSQL setup with direct PostgreSQL database configuration. Added a new insights service and adjusted management API setup.  Added project reference to `ABC.Management.Domain` in `ABC.Management.Api.Tests.csproj`  Replaced `ABC.PostGreSQL` references with `ABC.SharedEntityFramework` across multiple files, indicating a shift in the data access layer.  Modified `ABC.PostGreSQL.csproj` to reference `ABC.SharedEntityFramework` instead of `ABC.Management.Domain`.  Created `ABC.SharedEntityFramework.csproj` with Entity Framework Core references.

fix #7